### PR TITLE
fix: release workflow binary upload via workflow_call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,11 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ github.event.release.tag_name }}"
           fi
+          echo "version=$TAG" >> $GITHUB_OUTPUT
 
       - name: Flatten artifacts
         run: |
@@ -119,23 +117,9 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Upload Release Assets
-        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          files: release/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Release
-        if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: vox ${{ steps.version.outputs.version }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix binary upload not triggering when release-please calls release.yml via `workflow_call`
- Root cause: `github.event_name` is inherited as `push` from the caller, not `workflow_call`, so version extraction and upload conditions never matched
- Use `inputs.tag` directly (works for both `workflow_call` and `workflow_dispatch`) with fallback to `github.event.release.tag_name`
- Simplify to a single upload step instead of two conditional ones

## Test plan
- [ ] Merge this PR → release-please creates v0.2.1 PR
- [ ] Merge v0.2.1 PR → binaries should auto-upload to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)