### PR TITLE
fix: default init mode to mcp instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Linux requires `sudo apt install libasound2-dev`.
 ## Usage with Claude Code
 
 ```bash
-vox init                # all integrations (default)
-vox init -m mcp         # MCP server only
-vox init -m cli         # CLI hook only
-vox init -m skill       # slash command only
+vox init                # MCP server (default)
+vox init -m cli         # CLAUDE.md + Stop hook
+vox init -m skill       # /speak slash command
+vox init -m all         # all of the above
 ```
 
 Each mode sets up a different integration:

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,8 @@ enum Commands {
     Stats,
     /// Set up AI assistant integration (Claude Code + Claude Desktop)
     Init {
-        /// Integration mode: mcp, cli, skill, or all (default: all)
-        #[arg(short, long, default_value = "all")]
+        /// Integration mode: mcp, cli, skill, or all (default: mcp)
+        #[arg(short, long, default_value = "mcp")]
         mode: InitMode,
     },
     /// Launch MCP server (stdio transport for Claude Code / Claude Desktop)

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -281,7 +281,7 @@ fn test_init_creates_files() {
     let dir = tempfile::tempdir().unwrap();
     Command::cargo_bin("vox")
         .unwrap()
-        .arg("init")
+        .args(["init", "-m", "cli"])
         .current_dir(dir.path())
         .assert()
         .success()
@@ -299,7 +299,7 @@ fn test_init_idempotent() {
     // First run
     Command::cargo_bin("vox")
         .unwrap()
-        .arg("init")
+        .args(["init", "-m", "cli"])
         .current_dir(dir.path())
         .assert()
         .success();
@@ -307,7 +307,7 @@ fn test_init_idempotent() {
     // Second run
     Command::cargo_bin("vox")
         .unwrap()
-        .arg("init")
+        .args(["init", "-m", "cli"])
         .current_dir(dir.path())
         .assert()
         .success()


### PR DESCRIPTION
## Summary

- `vox init` defaults to `mcp` mode instead of `all`
- MCP provides contextual voice summaries via Claude (not a hardcoded "Terminé")
- `vox init -m cli` or `-m all` to opt into the Stop hook
- Tests updated to use explicit `-m cli` flag

## Test plan

- [x] `cargo test` passes (114 tests)
- [ ] CI passes on all platforms