### PR TITLE
fix: update README license from MIT to source-available

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ All state is stored locally in `~/.config/vox/`:
 
 ## License
 
-[MIT](LICENSE)
+[Source-Available](LICENSE) — Free for individuals and teams ≤ 20 people. Enterprise license required for larger organizations. Contact: license@rtk.ai


### PR DESCRIPTION
## Summary
- Update license badge and section in README to reflect source-available license

🤖 Generated with [Claude Code](https://claude.com/claude-code)