### PR TITLE
fix: default to say backend on macOS, kokoro on other platforms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+#[cfg(target_os = "macos")]
+pub const DEFAULT_BACKEND: &str = "say";
+#[cfg(not(target_os = "macos"))]
 pub const DEFAULT_BACKEND: &str = "kokoro";
 
 pub const SUPPORTED_LANGS: &[&str] = &[


### PR DESCRIPTION
## Summary
- Restore platform-specific default: `say` on macOS (native, fastest), `kokoro` on Linux/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)