### PR TITLE
docs: add technical, functional, and user guide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,75 @@
 # vox
 
-Cross-platform TTS CLI — local voice synthesis with three backends.
+Cross-platform TTS CLI with four backends and MCP server for AI assistants.
 
 ```
-                         vox
-                          |
-            +-------------+-------------+
-            |             |             |
-          say          qwen        qwen-native
-       (macOS)     (MLX/Python)    (pure Rust)
-        native      Apple Silicon   cross-platform
-                                   CPU/Metal/CUDA
-                          |
-                        rodio
-                    (audio playback)
+                           vox
+                            |
+          +--------+--------+--------+--------+
+          |        |                 |        |
+        say      qwen          qwen-native  kokoro
+     (macOS)  (MLX/Python)    (pure Rust)  (pure Rust)
+      native  Apple Silicon   CPU/Metal    CPU/GPU
+                               /CUDA
+                        |
+                      rodio
+                  (audio playback)
 ```
 
 ## Install
 
 ```bash
+# Quick install (macOS / Linux / WSL)
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/vox/main/install.sh | sh
+
 # From source
 cargo install --path .
 
-# Quick install (macOS / Linux / WSL)
-curl -fsSL https://raw.githubusercontent.com/rtk-ai/vox/main/install.sh | sh
+# With GPU acceleration
+cargo install --path . --features metal  # macOS Apple Silicon
+cargo install --path . --features cuda   # Linux NVIDIA
 ```
 
 | Platform | Default backend | GPU |
 |----------|----------------|-----|
 | macOS | `say` | `--features metal` |
-| Linux / WSL | `qwen-native` | `--features cuda` |
+| Linux / WSL | `kokoro` | `--features cuda` |
 
 Linux requires `sudo apt install libasound2-dev`.
 
-## Usage with Claude Code
+## Quick start
 
 ```bash
-vox init                # MCP server (default)
+vox "Hello, world."                     # Speak with default backend
+vox -b kokoro -l fr "Bonjour"           # Specific backend + language
+echo "Piped text" | vox                 # Read from stdin
+vox --list-voices                       # List available voices
+```
+
+## AI assistant integration
+
+One command configures **14 AI tools** (Claude Code, Cursor, VS Code, Zed, Codex, Gemini, Amazon Q, and more):
+
+```bash
+vox init                # MCP server (default) — all AI tools
 vox init -m cli         # CLAUDE.md + Stop hook
 vox init -m skill       # /speak slash command
 vox init -m all         # all of the above
 ```
 
-Each mode sets up a different integration:
-
-| Mode | What it does |
-|------|-------------|
-| `mcp` | Registers `vox serve` as an MCP server in `~/.claude.json` (Claude Code) and Claude Desktop config. Exposes 8 tools: `vox_speak`, `vox_list_voices`, `vox_clone_*`, `vox_config_*`, `vox_stats`. |
-| `cli` | Creates a `CLAUDE.md` in your project with instructions for Claude to call `vox` after significant tasks. Adds a `Stop` hook in `.claude/settings.json` that says "Terminé" after each response. |
-| `skill` | Creates a `/speak` slash command in `~/.claude/commands/speak.md`. |
-| `all` | Runs all three modes (default). |
+The MCP server exposes 14 tools: `vox_speak`, `vox_hear`, `vox_list_voices`, `vox_clone_*`, `vox_config_*`, `vox_stats`, `vox_pack_*`.
 
 ```
-  Claude Code
+  AI Assistant (Claude Code, Cursor, ...)
       |
    MCP stdio
       |
-  vox serve ──> vox_speak, vox_list_voices, ...
+  vox serve ──> vox_speak, vox_hear, vox_clone_add, ...
 ```
 
 Running `vox init` again is safe — it skips files that are already configured.
 
-## Standalone CLI
-
-```bash
-vox "Hello, world."
-vox -b qwen-native "Cross-platform TTS."
-echo "Hello" | vox
-vox --list-voices
-```
-
-### Voice cloning
+## Voice cloning
 
 ```bash
 vox clone add patrick --audio ~/voice.wav --text "Transcription"
@@ -80,25 +79,34 @@ vox clone list
 vox clone remove patrick
 ```
 
-### Preferences
+## Preferences
 
 ```bash
 vox config show
-vox config set backend qwen
+vox config set backend kokoro
 vox config set lang fr
 vox config set voice Chelsie
+vox config set gender feminine
+vox config set style warm
 vox config reset
 ```
 
-### Optional: Qwen backend (macOS)
-
-Neural TTS via Python/MLX on Apple Silicon:
+## Sound packs
 
 ```bash
-uv pip install mlx-audio
+vox pack install peon              # Install a pack
+vox pack set peon                  # Activate it
+vox pack play greeting             # Play a sound
+vox pack list                      # List available packs
 ```
 
-Model downloaded automatically on first use (~1.2 GB).
+## Voice conversation (macOS)
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+vox chat -l fr                     # Talk with Claude
+vox hear -l fr                     # Speech-to-text only
+```
 
 ## Data
 
@@ -106,8 +114,9 @@ All state is stored locally in `~/.config/vox/`:
 
 ```
 ~/.config/vox/
-├── vox.db          # SQLite: preferences, voice clones, usage logs
-└── clones/         # audio files for voice clones
+  vox.db          # SQLite: preferences, voice clones, usage logs
+  clones/         # Audio files for voice clones
+  packs/          # Installed sound packs
 ```
 
 | Env var | Description |
@@ -115,6 +124,14 @@ All state is stored locally in `~/.config/vox/`:
 | `VOX_CONFIG_DIR` | Override config directory |
 | `VOX_DB_PATH` | Override database path |
 
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](docs/ARCHITECTURE.md) | Architecture technique, backends, DB schema, protocole MCP, securite |
+| [Features](docs/FEATURES.md) | Documentation fonctionnelle de toutes les commandes et fonctionnalites |
+| [Guide](docs/GUIDE.md) | Guide utilisateur, installation, demarrage rapide, depannage |
+
 ## License
 
-[Source-Available](LICENSE) — Free for individuals and teams ≤ 20 people. Enterprise license required for larger organizations. Contact: license@rtk.ai
+[Source-Available](LICENSE) — Free for individuals and teams up to 20 people. Enterprise license required for larger organizations. Contact: license@rtk.ai

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,165 @@
+# Architecture technique
+
+## Vue d'ensemble
+
+vox est un CLI TTS cross-platform ecrit en Rust. Il transforme du texte en parole via quatre backends interchangeables et expose ses fonctionnalites comme serveur MCP (Model Context Protocol) pour l'integration avec les assistants IA.
+
+```
+                          vox (Rust)
+                              |
+            +---------+-------+-------+---------+
+            |         |               |         |
+          say      qwen          qwen-native  kokoro
+       (macOS)  (MLX/Python)    (pure Rust)  (pure Rust)
+       native   Apple Silicon   CPU/Metal    CPU/GPU
+                                /CUDA
+                    |
+                  rodio (audio playback cross-platform)
+```
+
+## Modules source
+
+```
+src/
+  main.rs         CLI (clap) — parsing args, dispatch subcommands
+  lib.rs          Exports publics des modules
+  mcp.rs          Serveur MCP JSON-RPC stdio (14 tools)
+  backend/
+    mod.rs        Trait TtsBackend + dispatch get_backend()
+    say.rs        Backend macOS natif (NSSSpeechSynthesizer via /usr/bin/say)
+    qwen.rs       Backend MLX-Audio Python (Apple Silicon, macOS only)
+    qwen_native.rs Backend candle/Rust (Qwen3-TTS, cross-platform)
+    kokoro.rs     Backend Kokoro-TTS (pure Rust, cross-platform)
+  config.rs       Chemins config, constantes, enums (Gender, IntonationStyle)
+  db.rs           SQLite (rusqlite) — preferences, clones, usage logs, stats
+  init.rs         Auto-configuration pour 14 outils IA
+  input.rs        Lecture texte (args, stdin, pipe)
+  clone.rs        Voice cloning — validation audio, enregistrement micro
+  pack.rs         Sound packs (peon-ping compatible)
+  audio.rs        Playback audio via rodio
+  stt.rs          Speech-to-text via mlx-whisper (macOS only)
+  chat/           Mode conversation vocale (macOS only)
+```
+
+## Backends TTS
+
+| Backend | Plateforme | Dependance | Latence | Voice cloning |
+|---------|-----------|------------|---------|---------------|
+| `say` | macOS uniquement | Aucune (systeme) | ~100ms | Non |
+| `qwen` | macOS (Apple Silicon) | `mlx-audio` (Python) | ~5-15s (cold) / ~1s (warm) | Oui |
+| `qwen-native` | Toutes | Aucune (Rust pur) | ~3-10s | Oui |
+| `kokoro` | Toutes | Aucune (Rust pur) | ~2-5s | Non |
+
+### Trait TtsBackend
+
+```rust
+pub trait TtsBackend {
+    fn name(&self) -> &str;
+    fn speak(&self, text: &str, opts: &SpeakOptions) -> Result<()>;
+    fn list_voices(&self) -> Result<Vec<String>>;
+    fn is_available(&self) -> bool;
+}
+```
+
+Chaque backend implemente ce trait. Le dispatch se fait via `get_backend(name)` dans `backend/mod.rs`.
+
+### Defaut par plateforme
+
+- **macOS**: `say` (zero latence, voix systeme)
+- **Linux / Windows**: `kokoro` (Rust pur, pas de dependance Python)
+
+## Base de donnees
+
+SQLite via `rusqlite` avec WAL mode. Fichier: `~/.config/vox/vox.db`.
+
+### Schema
+
+```sql
+-- Preferences utilisateur (une seule ligne, UPSERT)
+CREATE TABLE preferences (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    backend TEXT, voice TEXT, lang TEXT, rate INTEGER,
+    gender TEXT, style TEXT, model TEXT, pack TEXT
+);
+
+-- Voice clones
+CREATE TABLE voice_clones (
+    name TEXT PRIMARY KEY,
+    ref_audio TEXT NOT NULL,
+    ref_text TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Journal d'utilisation
+CREATE TABLE usage_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT DEFAULT (datetime('now')),
+    backend TEXT NOT NULL,
+    voice TEXT, lang TEXT,
+    text_len INTEGER NOT NULL,
+    duration_ms INTEGER
+);
+```
+
+### Requetes d'agregation
+
+- `get_usage_summary()` — total calls + total chars
+- `get_backend_stats()` — calls, chars, duration par backend
+- `get_lang_stats()` — calls par langue
+- `get_total_duration_ms()` — temps de parole cumule
+- `get_usage_stats()` — 50 dernieres entrees
+
+## Protocole MCP
+
+Serveur JSON-RPC 2.0 sur stdio. Compatible MCP spec `2024-11-05`.
+
+### Lifecycle
+
+1. Client envoie `initialize` → serveur repond avec capabilities + tools
+2. Client envoie `initialized` (notification)
+3. Client appelle `tools/call` avec `name` et `arguments`
+4. Serveur repond avec `content[{type: "text", text: "..."}]`
+
+### 14 outils MCP exposes
+
+| Tool | Description |
+|------|-------------|
+| `vox_speak` | Synthetise et joue du texte (params: text, voice, lang, backend) |
+| `vox_list_voices` | Liste les voix disponibles pour un backend |
+| `vox_clone_list` | Liste les voice clones enregistres |
+| `vox_clone_add` | Ajoute un voice clone (name, audio_path, ref_text) |
+| `vox_clone_remove` | Supprime un voice clone |
+| `vox_config_show` | Affiche les preferences courantes |
+| `vox_config_set` | Modifie une preference (key, value) |
+| `vox_stats` | Statistiques d'utilisation |
+| `vox_pack_list` | Liste les sound packs installes/disponibles |
+| `vox_pack_install` | Installe un sound pack |
+| `vox_pack_set` | Active un sound pack |
+| `vox_pack_play` | Joue un son d'un pack (category) |
+| `vox_pack_remove` | Supprime un sound pack |
+| `vox_hear` | Enregistre et transcrit (STT, macOS only) |
+
+## Compilation conditionnelle
+
+```rust
+#[cfg(target_os = "macos")]   // say, qwen, stt, chat
+#[cfg(not(target_os = "macos"))] // kokoro comme defaut
+```
+
+Feature flags Cargo:
+- `metal` — GPU Apple Silicon (Metal + Accelerate) pour qwen-native
+- `cuda` — GPU NVIDIA pour qwen-native
+
+## Securite
+
+- **SQL injection**: Toutes les requetes utilisent des parametres lies (`?`). Les cles de preference sont validees par whitelist.
+- **Path traversal**: Extensions audio validees (wav, mp3, flac, ogg, m4a). Fichiers verifies existants.
+- **Input validation**: Backends, langues, gender, style valides par enum/whitelist.
+- **Pas de shell**: Les commandes externes utilisent `std::process::Command` (pas de `sh -c`).
+
+## CI/CD
+
+- GitHub Actions: matrix macOS / Ubuntu / Windows
+- release-please: `feat:` → version bump PR → merge → release + binaires
+- Binaires: aarch64-apple-darwin, x86_64-apple-darwin (metal), x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc
+- Tests: `cargo test` (unitaires + integration UX/security/perf)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,196 @@
+# Documentation fonctionnelle
+
+## Synthese vocale (TTS)
+
+Fonctionnalite principale : transformer du texte en parole.
+
+```bash
+vox "Bonjour le monde"              # Backend par defaut
+vox -b kokoro "Hello world"         # Backend specifique
+vox -b qwen-native -l fr "Salut"   # Backend + langue
+echo "Texte pipe" | vox             # Lecture depuis stdin
+```
+
+### Options de parole
+
+| Flag | Description | Exemple |
+|------|-------------|---------|
+| `-b` | Backend TTS | `-b kokoro`, `-b say`, `-b qwen-native` |
+| `-v` | Voix ou clone | `-v Chelsie`, `-v patrick` |
+| `-l` | Langue | `-l fr`, `-l ja`, `-l en` |
+| `-r` | Debit (mots/min, backend say) | `-r 200` |
+| `--gender` | Genre vocal | `--gender feminine` |
+| `--style` | Intonation | `--style warm`, `--style energetic` |
+| `-m` | Modele TTS | `-m mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit` |
+
+### Langues supportees
+
+en, fr, es, de, it, pt, zh, ja, ko, ru, ar, nl
+
+### Styles d'intonation
+
+calm, energetic, warm, authoritative, cheerful, serious
+
+## Voice cloning
+
+Cloner une voix a partir d'un fichier audio de reference.
+
+```bash
+# Ajouter un clone depuis un fichier
+vox clone add patrick --audio ~/voice.wav --text "Transcription du fichier"
+
+# Enregistrer directement depuis le micro (necessite sox)
+vox clone record myvoice --duration 10 --text "Ce que je dis pendant l'enregistrement"
+
+# Utiliser un clone
+vox -v patrick "Ceci parle avec ma voix"
+
+# Gerer les clones
+vox clone list
+vox clone remove patrick
+```
+
+Formats audio acceptes : wav, mp3, flac, ogg, m4a.
+
+Le voice cloning bascule automatiquement sur le backend `qwen` (macOS) ou `qwen-native` (autres) car `say` et `kokoro` ne supportent pas le cloning.
+
+## Configuration
+
+Preferences persistantes en base SQLite.
+
+```bash
+vox config show                    # Afficher les preferences
+vox config set backend kokoro      # Changer le backend par defaut
+vox config set lang fr             # Langue par defaut
+vox config set voice Chelsie       # Voix par defaut
+vox config set gender feminine     # Genre vocal
+vox config set style warm          # Style d'intonation
+vox config set rate 180            # Debit (say uniquement)
+vox config set model <model_id>    # Modele TTS specifique
+vox config reset                   # Reinitialiser tout
+```
+
+Priorite de resolution : **flags CLI > preferences DB > valeurs par defaut**.
+
+## Sound packs
+
+Packs de sons thematiques (compatible peon-ping). Sons courts joues pour signaler des evenements.
+
+```bash
+vox pack list                      # Voir packs installes + disponibles
+vox pack install peon              # Installer un pack
+vox pack set peon                  # Activer un pack
+vox pack play greeting             # Jouer un son de la categorie "greeting"
+vox pack play error -p peon_fr     # Jouer depuis un pack specifique
+vox pack remove peon               # Desinstaller un pack
+```
+
+Categories de sons : greeting, acknowledge, complete, error, permission, annoyed.
+
+## Statistiques d'utilisation
+
+Dashboard complet de l'historique TTS.
+
+```bash
+vox stats
+```
+
+Affiche :
+- Temps de parole total (format humain : h/m/s)
+- Nombre total d'appels et de caracteres
+- Latence moyenne et throughput (chars/s)
+- Repartition par backend (calls, chars, duree, moyenne)
+- Repartition par langue (avec barres visuelles)
+- 10 derniers appels avec details
+
+## Integration IA (`vox init`)
+
+Configuration automatique pour 14 outils IA en une commande.
+
+```bash
+vox init                # Mode MCP (defaut) — configure tous les outils
+vox init -m cli         # Mode CLI — CLAUDE.md + Stop hook
+vox init -m skill       # Mode Skill — commande /speak
+vox init -m all         # Les trois modes
+```
+
+### Outils supportes (mode MCP)
+
+| Outil | Config |
+|-------|--------|
+| Claude Code | `~/.claude.json` |
+| Claude Desktop | Config specifique OS |
+| Cursor | `~/.cursor/mcp.json` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| VS Code / Copilot | `Code/User/mcp.json` |
+| Zed | `~/.config/zed/settings.json` |
+| Codex | `~/.codex/config.toml` |
+| OpenCode | `~/.config/opencode/opencode.json` |
+| Gemini Code Assist | `~/.gemini/settings.json` |
+| Amazon Q | `~/.aws/amazonq/mcp.json` |
+| Cline | Extension VS Code globalStorage |
+| Roo Code | Extension VS Code globalStorage |
+| Kilo Code | Extension VS Code globalStorage |
+| Amp | `~/.ampcode/settings.json` |
+
+L'init est idempotent : relancer `vox init` ne duplique pas les configurations.
+
+### Mode CLI
+
+Cree un `CLAUDE.md` dans le projet courant avec des instructions pour que l'assistant appelle `vox` apres les taches significatives. Ajoute un hook `Stop` dans `.claude/settings.json` qui dit "Termine" a la fin de chaque reponse.
+
+### Mode Skill
+
+Cree une commande `/speak` dans `~/.claude/commands/speak.md` pour invoquer vox via slash command.
+
+## Speech-to-Text (macOS)
+
+Transcription locale via mlx-whisper.
+
+```bash
+# CLI
+vox hear -l fr                     # Ecoute + transcription en francais
+vox hear -l en -t 60 -s 3.0       # Timeout 60s, silence 3s
+
+# Via MCP
+vox_hear                           # Utilise par l'assistant IA
+```
+
+Prerequis : `sox` (pour l'enregistrement micro) et `mlx-audio` (pour la transcription).
+
+## Mode conversation (macOS)
+
+Boucle vocale complete : ecouter → reflechir → parler.
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+vox chat                           # Conversation avec Claude
+vox chat -v patrick -l fr          # Avec voice clone en francais
+```
+
+Utilise Claude API en streaming pour la reflexion, STT local pour l'ecoute, et TTS pour la reponse.
+
+## Lecture de voix
+
+Lister les voix disponibles pour un backend.
+
+```bash
+vox --list-voices                  # Backend par defaut
+vox -b say --list-voices           # Voix macOS
+vox -b kokoro --list-voices        # Voix Kokoro
+```
+
+## Donnees locales
+
+Tout est stocke localement, aucune donnee n'est envoyee a un serveur externe (sauf le mode chat qui utilise l'API Claude).
+
+```
+~/.config/vox/
+  vox.db          # SQLite : preferences, clones, logs
+  clones/         # Fichiers audio des voice clones
+  packs/          # Sound packs installes
+```
+
+Variables d'environnement :
+- `VOX_CONFIG_DIR` — repertoire de configuration alternatif
+- `VOX_DB_PATH` — chemin de base de donnees alternatif

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,190 @@
+# Guide utilisateur
+
+## Installation
+
+### Script rapide (macOS / Linux / WSL)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/vox/main/install.sh | sh
+```
+
+### Depuis les sources
+
+```bash
+# Standard (CPU)
+cargo install --path .
+
+# macOS avec GPU Metal (recommande sur Apple Silicon)
+cargo install --path . --features metal
+
+# Linux avec GPU NVIDIA
+cargo install --path . --features cuda
+```
+
+### Prerequis optionnels
+
+| Composant | Pour quoi | Installation |
+|-----------|----------|--------------|
+| `mlx-audio` | Backend qwen (macOS) | `uv pip install mlx-audio` |
+| `sox` | Enregistrement micro (clone record, hear) | `brew install sox` / `apt install sox` |
+
+## Demarrage rapide
+
+```bash
+# Parler
+vox "Hello, world!"
+
+# En francais
+vox -l fr "Bonjour le monde"
+
+# Pipe depuis une commande
+echo "Message important" | vox
+
+# Voir les voix
+vox --list-voices
+```
+
+## Configuration avec un assistant IA
+
+La methode recommandee est d'utiliser vox comme serveur MCP :
+
+```bash
+vox init
+```
+
+Cette commande configure automatiquement **tous les outils IA** presents sur votre machine (Claude Code, Cursor, VS Code, Zed, etc.). Redemarrez votre outil apres l'init.
+
+L'assistant IA pourra alors :
+- Vous parler apres avoir termine une tache
+- Lister et changer les voix
+- Gerer vos voice clones
+- Jouer des sons de packs
+- Ecouter votre voix (STT, macOS)
+
+### Exemple avec Claude Code
+
+Apres `vox init`, Claude Code peut utiliser les outils MCP directement :
+
+```
+> Corrige le bug dans auth.rs
+
+[Claude corrige le bug, puis parle :]
+"Le bug d'authentification a ete corrige. Le token etait expire
+ car la duree etait en secondes au lieu de millisecondes."
+```
+
+## Personnaliser la voix
+
+```bash
+# Changer le backend par defaut
+vox config set backend kokoro
+
+# Voix feminine, style chaleureux
+vox config set gender feminine
+vox config set style warm
+
+# Langue par defaut
+vox config set lang fr
+
+# Voir la config actuelle
+vox config show
+```
+
+## Cloner votre voix
+
+Creez un clone vocal a partir d'un enregistrement audio :
+
+```bash
+# Depuis un fichier existant
+vox clone add mavoix --audio ~/enregistrement.wav --text "Transcription exacte"
+
+# Enregistrer depuis le micro (necessite sox)
+vox clone record mavoix --duration 10 --text "Ce que je dis"
+
+# Utiliser le clone
+vox -v mavoix "Ceci parle avec ma voix clonee"
+```
+
+Pour de meilleurs resultats :
+- Enregistrement de 5-15 secondes
+- Environnement calme, sans bruit de fond
+- Parler naturellement, pas trop vite
+- Fournir la transcription exacte avec `--text`
+
+## Sound packs
+
+Ajoutez des sons thematiques (style Warcraft peon, StarCraft, etc.) :
+
+```bash
+vox pack install peon          # Installer
+vox pack set peon              # Activer
+vox pack play greeting         # "Ready to work!"
+vox pack play complete         # "Work complete."
+vox pack play error            # "Can't do that."
+```
+
+Voir les packs disponibles : `vox pack list`
+
+## Conversation vocale (macOS)
+
+Discutez vocalement avec Claude :
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+vox chat -l fr
+```
+
+La boucle : vous parlez → Whisper transcrit → Claude repond → vox parle la reponse.
+
+## Transcription (macOS)
+
+Enregistrez et transcrivez votre voix :
+
+```bash
+vox hear -l fr
+# Parlez... (s'arrete apres 2s de silence)
+# => "Votre texte transcrit ici"
+```
+
+## Backends en detail
+
+### say (macOS natif)
+- Latence quasi-nulle (~100ms)
+- Voix Apple integrees (Samantha, Thomas, etc.)
+- Support du debit (`-r 200`)
+- Pas de voice cloning
+
+### kokoro (Rust pur)
+- Cross-platform, zero dependance externe
+- Bonne qualite vocale
+- ~2-5s de latence
+- Pas de voice cloning
+
+### qwen (MLX Python, macOS)
+- Qualite neurale superieure
+- Voice cloning supporte
+- Necessite `mlx-audio` + Apple Silicon
+- ~1s warm / ~5-15s cold start
+
+### qwen-native (Rust pur)
+- Meme modele Qwen3-TTS mais en Rust (candle)
+- Voice cloning supporte
+- GPU via Metal (macOS) ou CUDA (Linux)
+- Cross-platform
+
+## Depannage
+
+### "command not found: vox"
+Le binaire n'est pas dans votre PATH. Verifiez avec `which vox` ou reinstallez.
+
+### "Backend 'say' is only available on macOS"
+Utilisez `kokoro` ou `qwen-native` sur Linux/Windows : `vox config set backend kokoro`
+
+### Backend qwen lent au premier lancement
+Normal : le modele (~1.2 GB) est telecharge automatiquement. Les lancements suivants sont plus rapides.
+
+### Enregistrement micro ne fonctionne pas
+Installez sox : `brew install sox` (macOS) ou `apt install sox` (Linux).
+
+### "ANTHROPIC_API_KEY is required" (chat mode)
+Exportez votre cle API : `export ANTHROPIC_API_KEY=sk-ant-...`

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,3 +1,7 @@
+//! Cross-platform audio playback via rodio.
+//!
+//! Supports blocking and async (threaded) playback of WAV/MP3/OGG/FLAC files.
+
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;

--- a/src/backend/kokoro.rs
+++ b/src/backend/kokoro.rs
@@ -1,3 +1,7 @@
+//! Kokoro TTS backend — pure Rust ONNX inference via Python kokoro-onnx bridge.
+//!
+//! Cross-platform, no GPU required. Model files (~80MB) downloaded separately.
+
 use std::process::Command;
 
 use anyhow::{Context, Result};

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,3 +1,8 @@
+//! TTS backend abstraction layer.
+//!
+//! Each backend implements `TtsBackend` and is selected at runtime via `get_backend()`.
+//! Platform-gated: `say` and `qwen` are macOS-only; `kokoro` and `qwen-native` are cross-platform.
+
 pub mod kokoro;
 #[cfg(target_os = "macos")]
 pub mod qwen;

--- a/src/backend/qwen.rs
+++ b/src/backend/qwen.rs
@@ -1,3 +1,8 @@
+//! Qwen TTS backend — MLX-Audio Python on Apple Silicon (macOS only).
+//!
+//! Supports voice cloning via ref_audio/ref_text. Multi-chunk pipeline overlaps
+//! generation with playback to reduce perceived latency on long texts.
+
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 

--- a/src/backend/qwen_native.rs
+++ b/src/backend/qwen_native.rs
@@ -1,3 +1,9 @@
+//! Qwen-native TTS backend — pure Rust inference via candle (qwen3-tts-rs).
+//!
+//! Cross-platform with optional Metal (macOS) or CUDA (Linux) GPU acceleration.
+//! Model is loaded once and kept warm in a global Mutex for the process lifetime.
+//! Supports voice cloning via reference audio + text prompt.
+
 use std::sync::Mutex;
 
 use anyhow::{Context, Result};

--- a/src/backend/say.rs
+++ b/src/backend/say.rs
@@ -1,3 +1,7 @@
+//! macOS `say` backend — system TTS via /usr/bin/say.
+//!
+//! Near-zero latency, uses Apple's built-in voices. No voice cloning support.
+
 use std::process::Command;
 
 use anyhow::{Context, Result};

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,3 +1,5 @@
+//! Voice cloning — audio validation, microphone recording, clone resolution.
+
 use std::path::Path;
 use std::process::Command;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+//! Configuration paths, platform defaults, and validation enums.
+
 use std::path::PathBuf;
 
 #[cfg(target_os = "macos")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,8 @@
+//! SQLite database — preferences, voice clones, usage logging, and statistics.
+//!
+//! All state is persisted in `~/.config/vox/vox.db` with WAL mode enabled.
+//! Schema is auto-migrated on first open.
+
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,3 +1,8 @@
+//! Auto-configuration for 14 AI tools (Claude Code, Cursor, VS Code, Zed, etc.).
+//!
+//! `vox init` injects MCP server config into each tool's settings file.
+//! Idempotent — safe to run multiple times without duplicating entries.
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,5 @@
+//! Text input handling — CLI arguments or stdin pipe.
+
 use std::io::{self, IsTerminal, Read};
 
 use anyhow::{Result, bail};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! vox — Cross-platform TTS CLI with MCP server for AI assistants.
+//!
+//! Four backends: `say` (macOS native), `qwen` (MLX Python), `qwen-native` (pure Rust),
+//! `kokoro` (pure Rust). Exposes 14 MCP tools over stdio for integration with
+//! Claude Code, Cursor, VS Code, and 11 other AI tools.
+
 pub mod audio;
 pub mod backend;
 #[cfg(target_os = "macos")]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,3 +1,8 @@
+//! MCP (Model Context Protocol) server — JSON-RPC 2.0 over stdio.
+//!
+//! Exposes 14 tools for AI assistants: speak, hear, voice cloning, config, stats, packs.
+//! Launched via `vox serve` and auto-configured by `vox init` for 14 AI tools.
+
 use std::io::{self, BufRead, Write};
 
 use anyhow::Result;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,3 +1,8 @@
+//! Sound packs — themed audio clips (peon-ping compatible).
+//!
+//! Packs are downloaded from the peon-ping GitHub repo and stored in `~/.config/vox/packs/`.
+//! Each pack has a manifest.json with categories (greeting, complete, error, etc.).
+
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;

--- a/src/stt.rs
+++ b/src/stt.rs
@@ -1,3 +1,7 @@
+//! Speech-to-text via mlx-whisper (macOS only).
+//!
+//! Runs `mlx_whisper.transcribe()` in a Python subprocess, returns the text as a String.
+
 use std::process::Command;
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary
- Add `docs/ARCHITECTURE.md` — technical architecture, backends, DB schema, MCP protocol, security
- Add `docs/FEATURES.md` — all features and commands documented in French
- Add `docs/GUIDE.md` — installation, quick start, troubleshooting guide
- Update `README.md` with correct 4-backend diagram (was 3), docs links, and full feature coverage
- Add `//!` module-level doc comments to all 13 source modules

## Test plan
- [x] `cargo build` passes
- [x] No code logic changed, documentation only