### PR TITLE
fix: revert kokoro to Python, restore say default on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4070,6 +4070,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures-util",
+ "hound",
  "predicates",
  "qwen3-tts",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 rodio = "0.20"
+hound = "3"
 qwen3-tts = { git = "https://github.com/TrevorS/qwen3-tts-rs", features = ["hub"], default-features = false }
 ratatui = "0.29"
 crossterm = "0.28"

--- a/src/backend/kokoro.rs
+++ b/src/backend/kokoro.rs
@@ -1,13 +1,13 @@
-//! Kokoro TTS backend — pure Rust ONNX inference via Python kokoro-onnx bridge.
+//! Kokoro TTS backend — ONNX model via Python kokoro-onnx bridge.
 //!
-//! Cross-platform, no GPU required. Model files (~80MB) downloaded separately.
+//! 82M param model, cross-platform. Model files (~80MB) downloaded separately.
+//! Note: uses Python subprocess for now. Pure Rust port tracked as future work.
 
 use std::process::Command;
 
 use anyhow::{Context, Result};
 
 use super::{SpeakOptions, TtsBackend};
-use crate::audio;
 use crate::config;
 
 const MODEL_FILE: &str = "kokoro-v1.0.onnx";
@@ -122,7 +122,22 @@ sf.write("{out}", samples, sr)
             anyhow::bail!("Kokoro TTS failed: {stderr}");
         }
 
-        audio::play_wav_blocking(&wav_path)?;
+        // Use afplay on macOS (more reliable), rodio on other platforms
+        #[cfg(target_os = "macos")]
+        {
+            let status = Command::new("afplay")
+                .arg(&wav_path)
+                .status()
+                .context("failed to play audio")?;
+            if !status.success() {
+                anyhow::bail!("afplay failed");
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            crate::audio::play_wav_blocking(&wav_path)?;
+        }
+
         let _ = std::fs::remove_file(&wav_path);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Revert kokoro backend to Python subprocess (kokoros Rust crate has upstream bug: generates only 0.5s audio)
- Restore `say` as default backend on macOS for reliability
- Keep `hound` dep for future Rust WAV writing

## Test plan
- [x] `vox "test"` uses say on macOS, works
- [x] `vox -b kokoro "test"` uses Python, works