### PR TITLE
fix: resolve clippy CI failures

### DIFF
--- a/src/backend/voxtream.rs
+++ b/src/backend/voxtream.rs
@@ -73,13 +73,10 @@ pub fn find_voxtream() -> Option<PathBuf> {
         dirs::home_dir().map(|h| h.join("venvs/voxtream/bin/voxtream")),
     ];
 
-    for candidate in candidates.into_iter().flatten() {
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-
-    None
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|candidate| candidate.exists())
 }
 
 impl TtsBackend for VoxtreamBackend {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -356,7 +356,7 @@ async fn handle_connection(stream: tokio::net::TcpStream, state: Arc<DaemonState
 
     let mut request_line = String::new();
     buf_reader.read_line(&mut request_line).await?;
-    let parts: Vec<&str> = request_line.trim().split_whitespace().collect();
+    let parts: Vec<&str> = request_line.split_whitespace().collect();
     if parts.len() < 2 {
         return Ok(());
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -295,7 +295,7 @@ fn draw(frame: &mut Frame, app: &App) {
     .split(outer[1]);
 
     // Backend list
-    let backend_items: Vec<&str> = app.backends.iter().copied().collect();
+    let backend_items: Vec<&str> = app.backends.to_vec();
     frame.render_widget(
         render_list(
             "Backend",


### PR DESCRIPTION
Fix 3 clippy warnings treated as errors: manual_find, trim_split_whitespace, iter_cloned_collect.