### PR TITLE
feat: full Rust piper backend + TUI quality ratings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
@@ -204,19 +204,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -255,9 +284,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block"
@@ -534,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,7 +686,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
 ]
 
 [[package]]
@@ -714,7 +752,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -845,6 +883,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,7 +956,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -995,6 +1043,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "espeak-rs"
+version = "0.1.9"
+source = "git+https://github.com/thewh1teagle/piper-rs#616e6823cc29955bb0cf66532637b352b26fa292"
+dependencies = [
+ "espeak-rs-sys",
+]
+
+[[package]]
+name = "espeak-rs-sys"
+version = "0.1.9"
+source = "git+https://github.com/thewh1teagle/piper-rs#616e6823cc29955bb0cf66532637b352b26fa292"
+dependencies = [
+ "bindgen 0.69.5",
+ "cmake",
+ "glob",
 ]
 
 [[package]]
@@ -1574,8 +1640,23 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
+ "ureq 2.12.1",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1893,6 +1974,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1964,6 +2054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lewton"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,7 +2108,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -2070,6 +2166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,7 +2237,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -2208,12 +2320,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2409,7 +2551,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -2426,7 +2568,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -2439,7 +2581,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2",
  "dispatch2",
  "objc2",
@@ -2497,7 +2639,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2519,7 +2661,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2564,6 +2706,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+dependencies = [
+ "ndarray 0.17.2",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq 3.3.0",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2786,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper-rs"
+version = "0.1.9"
+source = "git+https://github.com/thewh1teagle/piper-rs#616e6823cc29955bb0cf66532637b352b26fa292"
+dependencies = [
+ "espeak-rs",
+ "ndarray 0.16.1",
+ "ort",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2808,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2668,6 +2864,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2822,7 +3028,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str 0.8.1",
  "crossterm",
@@ -2843,8 +3049,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2898,7 +3110,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3034,13 +3246,19 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3068,7 +3286,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3081,7 +3299,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -3186,7 +3404,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3508,7 +3726,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -3522,7 +3740,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3775,7 +3993,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4008,6 +4226,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,6 +4266,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4071,6 +4325,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "hound",
+ "piper-rs",
  "predicates",
  "qwen3-tts",
  "ratatui",
@@ -4219,6 +4474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,6 +4498,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3"
 rodio = "0.20"
 hound = "3"
 qwen3-tts = { git = "https://github.com/TrevorS/qwen3-tts-rs", features = ["hub"], default-features = false }
+piper-rs = { git = "https://github.com/thewh1teagle/piper-rs" }
 ratatui = "0.29"
 crossterm = "0.28"
 

--- a/src/backend/piper.rs
+++ b/src/backend/piper.rs
@@ -1,52 +1,33 @@
-//! Piper TTS backend — fast local neural TTS via ONNX.
+//! Piper TTS backend — full Rust via piper-rs (ONNX Runtime + espeak-rs).
 //!
-//! 15-80MB models, <1s inference on CPU, 30+ languages.
-//! Requires: `pip install piper-tts` and ONNX model files.
+//! Multilingual neural TTS, <1s inference on CPU, 30+ languages.
+//! Zero Python dependency. Model files auto-downloaded from HuggingFace.
 
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
+use piper_rs::Piper;
 
 use super::{SpeakOptions, TtsBackend};
 use crate::config;
 
 pub struct PiperBackend;
 
-/// Find the piper binary — check PATH first, then common venv locations.
-pub fn find_piper() -> Option<PathBuf> {
-    if let Ok(status) = Command::new("piper")
-        .arg("--help")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-    {
-        if status.success() {
-            return Some(PathBuf::from("piper"));
-        }
-    }
-
-    let candidates = [
-        dirs::home_dir().map(|h| h.join(".local/venvs/piper/bin/piper")),
-        dirs::home_dir().map(|h| h.join(".venvs/piper/bin/piper")),
-    ];
-
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|candidate| candidate.exists())
-}
+/// Cached model — (language, Piper instance).
+/// Reloads when language changes (different ONNX model per language).
+static MODEL: Mutex<Option<(String, Piper)>> = Mutex::new(None);
 
 fn models_dir() -> PathBuf {
     config::config_dir().join("piper")
 }
 
-/// Map lang code to piper model name and download URL.
+/// Map lang code to (model_name, download_base_url).
 fn model_for_lang(lang: &str) -> (&'static str, &'static str) {
     match lang {
         "fr" => (
-            "fr_FR-siwis-medium",
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/siwis/medium",
+            "fr_FR-tom-medium",
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/fr/fr_FR/tom/medium",
         ),
         "es" => (
             "es_ES-davefx-medium",
@@ -80,6 +61,14 @@ fn model_for_lang(lang: &str) -> (&'static str, &'static str) {
             "ru_RU-irina-medium",
             "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium",
         ),
+        "ar" => (
+            "ar_JO-kareem-medium",
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ar/ar_JO/kareem/medium",
+        ),
+        "nl" => (
+            "nl_NL-mls-medium",
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/nl/nl_NL/mls/medium",
+        ),
         _ => (
             "en_US-lessac-medium",
             "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium",
@@ -87,8 +76,8 @@ fn model_for_lang(lang: &str) -> (&'static str, &'static str) {
     }
 }
 
-/// Ensure model files exist, downloading if needed.
-fn ensure_model(lang: &str) -> Result<PathBuf> {
+/// Ensure model files exist, downloading if needed. Returns (onnx_path, json_path).
+fn ensure_model(lang: &str) -> Result<(PathBuf, PathBuf)> {
     let (model_name, base_url) = model_for_lang(lang);
     let dir = models_dir();
     std::fs::create_dir_all(&dir).ok();
@@ -103,6 +92,11 @@ fn ensure_model(lang: &str) -> Result<PathBuf> {
             .and_then(|r| r.bytes())
             .with_context(|| format!("failed to download {model_name}.onnx"))?;
         std::fs::write(&onnx_path, &bytes)?;
+        eprintln!(
+            "Downloaded {} ({:.1} MB)",
+            model_name,
+            bytes.len() as f64 / 1_000_000.0
+        );
     }
 
     if !json_path.exists() {
@@ -113,7 +107,30 @@ fn ensure_model(lang: &str) -> Result<PathBuf> {
         std::fs::write(&json_path, &bytes)?;
     }
 
-    Ok(onnx_path)
+    Ok((onnx_path, json_path))
+}
+
+fn get_or_load_model(
+    lang: &str,
+) -> Result<std::sync::MutexGuard<'static, Option<(String, Piper)>>> {
+    let mut guard = MODEL
+        .lock()
+        .map_err(|e| anyhow::anyhow!("model lock poisoned: {e}"))?;
+
+    // Reload if language changed
+    let need_reload = match &*guard {
+        Some((cached_lang, _)) => cached_lang != lang,
+        None => true,
+    };
+
+    if need_reload {
+        let (onnx_path, json_path) = ensure_model(lang)?;
+        let model = Piper::new(&onnx_path, &json_path)
+            .map_err(|e| anyhow::anyhow!("failed to load piper model: {e}"))?;
+        *guard = Some((lang.to_string(), model));
+    }
+
+    Ok(guard)
 }
 
 impl TtsBackend for PiperBackend {
@@ -122,58 +139,40 @@ impl TtsBackend for PiperBackend {
     }
 
     fn speak(&self, text: &str, opts: &SpeakOptions) -> Result<()> {
-        let bin = find_piper().context(
-            "piper not found. Install it:\n\
-             uv venv ~/.local/venvs/piper --python 3.11\n\
-             uv pip install --python ~/.local/venvs/piper/bin/python piper-tts",
-        )?;
-
         let lang = opts.lang.as_deref().unwrap_or("en");
-        let model_path = ensure_model(lang)?;
 
+        let mut guard = get_or_load_model(lang)?;
+        let (_, model) = guard.as_mut().context("model not loaded")?;
+
+        let (audio_data, sample_rate) = model
+            .create(text, false, None, None, None, None)
+            .map_err(|e| anyhow::anyhow!("Piper TTS failed: {e}"))?;
+
+        if audio_data.is_empty() {
+            return Ok(());
+        }
+
+        // Write to temp WAV
         let tmp = tempfile::NamedTempFile::new().context("failed to create temp file")?;
         let wav_path = tmp.path().with_extension("wav");
 
-        let mut cmd = Command::new(&bin);
-        cmd.arg("--model").arg(&model_path);
-        cmd.arg("-f").arg(&wav_path);
-
-        if let Some(ref voice) = opts.voice {
-            // Piper voices are speaker IDs (integers) for multi-speaker models
-            if let Ok(speaker_id) = voice.parse::<u32>() {
-                cmd.arg("-s").arg(speaker_id.to_string());
-            }
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec)?;
+        for sample in &audio_data {
+            let s = (*sample * 32767.0).clamp(-32768.0, 32767.0) as i16;
+            writer.write_sample(s)?;
         }
-
-        // Enable CUDA if available (NVIDIA GPU)
-        if std::path::Path::new("/usr/bin/nvidia-smi").exists()
-            || std::env::var("CUDA_VISIBLE_DEVICES").is_ok()
-        {
-            cmd.arg("--cuda");
-        }
-
-        let mut child = cmd
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .context("failed to run piper")?;
-
-        if let Some(ref mut stdin) = child.stdin {
-            use std::io::Write;
-            stdin.write_all(text.as_bytes()).ok();
-        }
-        drop(child.stdin.take());
-
-        let status = child.wait().context("piper process failed")?;
-        if !status.success() {
-            anyhow::bail!("piper exited with status {status}");
-        }
+        writer.finalize()?;
 
         // Play audio
         #[cfg(target_os = "macos")]
         {
-            Command::new("afplay")
+            std::process::Command::new("afplay")
                 .arg(&wav_path)
                 .status()
                 .context("failed to play audio")?;
@@ -199,10 +198,12 @@ impl TtsBackend for PiperBackend {
             "ja_JP-kokoro-medium".into(),
             "ko_KR-kss-medium".into(),
             "ru_RU-irina-medium".into(),
+            "ar_JO-kareem-medium".into(),
+            "nl_NL-mls-medium".into(),
         ])
     }
 
     fn is_available(&self) -> bool {
-        find_piper().is_some()
+        true
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,9 @@
 
 use std::path::PathBuf;
 
+#[cfg(target_os = "macos")]
+pub const DEFAULT_BACKEND: &str = "say";
+#[cfg(not(target_os = "macos"))]
 pub const DEFAULT_BACKEND: &str = "piper";
 
 pub const SUPPORTED_LANGS: &[&str] = &[

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -46,14 +46,26 @@ impl App {
         let prefs = db::get_preferences(&conn)?;
 
         #[cfg(target_os = "macos")]
-        let backends = vec!["say", "kokoro", "qwen", "qwen-native", "voxtream"];
+        let backends = vec![
+            "say          \u{2605}\u{2605}\u{2605} quality  \u{26a1} 3s",
+            "piper        \u{2605}\u{2605}  quality  \u{26a1} <1s  [Rust]",
+            "qwen-native  \u{2605}\u{2605}\u{2605}\u{2605} quality  \u{26a1} 12s  [Rust+Metal]",
+            "voxtream     \u{2605}\u{2605}\u{2605}\u{2605}\u{2605} quality  \u{26a1} 170ms [CUDA]",
+            "kokoro       \u{2605}\u{2605}  quality  \u{26a1} 10s  [Python]",
+            "qwen         \u{2605}\u{2605}\u{2605}\u{2605} quality  \u{26a1} 2s   [Python+MLX]",
+        ];
         #[cfg(not(target_os = "macos"))]
-        let backends = vec!["kokoro", "qwen-native", "voxtream"];
+        let backends = vec![
+            "piper        \u{2605}\u{2605}  quality  \u{26a1} <1s  [Rust]",
+            "qwen-native  \u{2605}\u{2605}\u{2605}\u{2605} quality  \u{26a1} 3s   [Rust+CUDA]",
+            "voxtream     \u{2605}\u{2605}\u{2605}\u{2605}\u{2605} quality  \u{26a1} 170ms [CUDA]",
+            "kokoro       \u{2605}\u{2605}  quality  \u{26a1} 10s  [Python]",
+        ];
 
         let current_backend = prefs.backend.as_deref().unwrap_or(config::DEFAULT_BACKEND);
         let backend_idx = backends
             .iter()
-            .position(|b| *b == current_backend)
+            .position(|b| b.split_whitespace().next() == Some(current_backend))
             .unwrap_or(0);
 
         let languages: Vec<&str> = config::SUPPORTED_LANGS.to_vec();
@@ -108,7 +120,11 @@ impl App {
     }
 
     fn selected_backend(&self) -> &str {
+        // Extract backend name (first word before spaces)
         self.backends[self.backend_idx]
+            .split_whitespace()
+            .next()
+            .unwrap_or("say")
     }
 
     fn selected_lang(&self) -> &str {
@@ -149,7 +165,11 @@ impl App {
         match self.screen {
             Screen::Backend => {
                 self.backend_idx = idx;
-                self.voices = Self::load_voices(self.backends[idx]);
+                let name = self.backends[idx]
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("say");
+                self.voices = Self::load_voices(name);
                 self.voice_idx = 0;
             }
             Screen::Voice => self.voice_idx = idx,


### PR DESCRIPTION
## Summary
- Replace Python piper with **piper-rs** (full Rust: ort + espeak-rs)
- 12 languages, auto-download models from HuggingFace
- Quality/speed star ratings in `vox setup` TUI
- Default: say (macOS), piper (Linux/Windows)

Zero Python for piper backend.

## Test plan
- [x] `cargo build` passes
- [x] English + French TTS works
- [x] Model auto-downloads on first use
- [x] TUI shows ratings