### PR TITLE
feat: add --volume flag for audio gain control

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Linux requires `sudo apt install libasound2-dev`.
 vox "Hello, world."                     # Speak with default backend
 vox -b voxtream "Zero-shot TTS."        # VoXtream2 (fastest neural)
 vox -b kokoro -l fr "Bonjour"           # Kokoro with language
+vox --volume 2.0 "Louder!"             # 2x volume (range: 0.0–5.0)
 echo "Piped text" | vox                 # Read from stdin
 vox --list-voices                       # List available voices
 vox setup                               # Interactive TUI configuration

--- a/README_es.md
+++ b/README_es.md
@@ -39,6 +39,7 @@ cargo install --path . --features cuda   # Linux NVIDIA
 vox "Hola, mundo."                      # Hablar con el backend por defecto
 vox -b voxtream "Zero-shot TTS."        # VoXtream2 (el mas rapido)
 vox -b kokoro -l es "Hola mundo"        # Kokoro en espanol
+vox --volume 2.0 "¡Mas fuerte!"        # Volumen 2x (rango: 0.0–5.0)
 echo "Texto pipe" | vox                 # Leer desde stdin
 vox setup                               # Configuracion interactiva (TUI)
 ```

--- a/README_fr.md
+++ b/README_fr.md
@@ -39,6 +39,7 @@ cargo install --path . --features cuda   # Linux NVIDIA
 vox "Bonjour le monde"                  # Parler avec le backend par defaut
 vox -b voxtream "Zero-shot TTS."        # VoXtream2 (le plus rapide)
 vox -b kokoro -l fr "Bonjour"           # Kokoro avec langue
+vox --volume 2.0 "Plus fort !"         # Volume 2x (plage : 0.0–5.0)
 echo "Texte pipe" | vox                 # Lire depuis stdin
 vox setup                               # Configuration interactive (TUI)
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -39,6 +39,7 @@ cargo install --path . --features cuda   # Linux NVIDIA
 vox "Hello, world."                     # デフォルトバックエンドで読み上げ
 vox -b voxtream "Zero-shot TTS."        # VoXtream2（最速）
 vox -b kokoro -l ja "こんにちは"         # Kokoro 日本語
+vox --volume 2.0 "もっと大きく！"       # 2倍音量（範囲：0.0–5.0）
 echo "パイプテキスト" | vox              # 標準入力から読み取り
 vox setup                               # インタラクティブ設定（TUI）
 ```

--- a/README_ko.md
+++ b/README_ko.md
@@ -39,6 +39,7 @@ cargo install --path . --features cuda   # Linux NVIDIA
 vox "Hello, world."                     # 기본 백엔드로 읽기
 vox -b voxtream "Zero-shot TTS."        # VoXtream2 (가장 빠름)
 vox -b kokoro -l ko "안녕하세요"         # Kokoro 한국어
+vox --volume 2.0 "더 크게!"            # 2배 볼륨 (범위: 0.0–5.0)
 echo "파이프 텍스트" | vox               # 표준 입력에서 읽기
 vox setup                               # 대화형 설정 (TUI)
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,7 @@ cargo install --path . --features cuda   # Linux NVIDIA
 vox "Hello, world."                     # 使用默认后端朗读
 vox -b voxtream "Zero-shot TTS."        # VoXtream2（最快）
 vox -b kokoro -l zh "你好世界"           # Kokoro 中文
+vox --volume 2.0 "大声点！"            # 2倍音量（范围：0.0–5.0）
 echo "管道文本" | vox                    # 从标准输入读取
 vox setup                               # 交互式配置（TUI）
 ```

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -9,6 +9,51 @@ use std::thread;
 
 use anyhow::{Context, Result};
 
+/// Apply volume gain to a WAV file in-place by rewriting the sample data.
+/// A volume of 1.0 leaves the file unchanged.
+pub fn apply_wav_gain(path: &Path, volume: f32) -> Result<()> {
+    if (volume - 1.0).abs() <= f32::EPSILON {
+        return Ok(());
+    }
+    let mut reader = hound::WavReader::open(path)
+        .with_context(|| format!("Failed to open WAV for gain: {}", path.display()))?;
+    let spec = reader.spec().clone();
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Float => reader.samples::<f32>().collect::<Result<Vec<_>, _>>()?,
+        hound::SampleFormat::Int => {
+            let bits = spec.bits_per_sample;
+            let max_val = (1i32 << (bits - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / max_val))
+                .collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    let gained: Vec<f32> = samples
+        .iter()
+        .map(|s| (s * volume).clamp(-1.0, 1.0))
+        .collect();
+
+    // Always write back as 16-bit signed int
+    let out_spec = hound::WavSpec {
+        channels: spec.channels,
+        sample_rate: spec.sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, out_spec)
+        .with_context(|| format!("Failed to rewrite WAV: {}", path.display()))?;
+    for &sample in &gained {
+        let scaled = (sample * 32767.0) as i16;
+        writer.write_sample(scaled)?;
+    }
+    writer.finalize()?;
+
+    Ok(())
+}
+
 /// Play a WAV file and block until playback finishes.
 pub fn play_wav_blocking(path: &Path) -> Result<()> {
     play_audio_blocking(path)

--- a/src/backend/kokoro.rs
+++ b/src/backend/kokoro.rs
@@ -203,6 +203,7 @@ impl TtsBackend for KokoroBackend {
         let wav_path = tmp.path().with_extension("wav");
         write_wav(&wav_path, &samples, SAMPLE_RATE)?;
 
+        crate::audio::apply_wav_gain(&wav_path, opts.volume)?;
         crate::audio::play_wav_blocking(&wav_path)?;
         let _ = std::fs::remove_file(&wav_path);
         Ok(())

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,7 +15,7 @@ pub mod voxtream;
 
 use anyhow::Result;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SpeakOptions {
     pub voice: Option<String>,
     pub lang: Option<String>,
@@ -25,6 +25,23 @@ pub struct SpeakOptions {
     pub ref_audio: Option<String>,
     pub ref_text: Option<String>,
     pub model: Option<String>,
+    pub volume: f32,
+}
+
+impl Default for SpeakOptions {
+    fn default() -> Self {
+        Self {
+            voice: None,
+            lang: None,
+            rate: None,
+            gender: None,
+            style: None,
+            ref_audio: None,
+            ref_text: None,
+            model: None,
+            volume: 1.0,
+        }
+    }
 }
 
 pub trait TtsBackend {

--- a/src/backend/piper.rs
+++ b/src/backend/piper.rs
@@ -179,6 +179,7 @@ impl TtsBackend for PiperBackend {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            crate::audio::apply_wav_gain(&wav_path, opts.volume)?;
             crate::audio::play_wav_blocking(&wav_path)?;
         }
 

--- a/src/backend/qwen_native.rs
+++ b/src/backend/qwen_native.rs
@@ -89,7 +89,7 @@ impl TtsBackend for QwenNativeBackend {
         let ref_audio_path = opts.ref_audio.clone();
         let ref_text = opts.ref_text.clone();
 
-        let audio_buf = with_model(opts.model.as_deref(), |model| {
+        let mut audio_buf = with_model(opts.model.as_deref(), |model| {
             if let Some(ref path) = ref_audio_path {
                 let ref_audio = AudioBuffer::load(path)
                     .with_context(|| format!("failed to load reference audio: {path}"))?;
@@ -99,6 +99,13 @@ impl TtsBackend for QwenNativeBackend {
                 Ok(model.synthesize(text, None)?)
             }
         })?;
+
+        // Apply volume gain to audio buffer
+        if (opts.volume - 1.0).abs() > f32::EPSILON {
+            for sample in &mut audio_buf.samples {
+                *sample = (*sample * opts.volume).clamp(-1.0, 1.0);
+            }
+        }
 
         // Save to temp file and play with rodio
         let tmp = tempfile::NamedTempFile::new().context("failed to create temp file")?;

--- a/src/backend/voxtream.rs
+++ b/src/backend/voxtream.rs
@@ -144,6 +144,7 @@ impl TtsBackend for VoxtreamBackend {
             anyhow::bail!("VoXtream2 TTS failed: {stderr}");
         }
 
+        audio::apply_wav_gain(&wav_path, opts.volume)?;
         audio::play_wav_blocking(&wav_path)?;
         let _ = std::fs::remove_file(&wav_path);
         Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -98,6 +98,20 @@ pub struct SpeakRequest {
     pub ref_text: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default = "default_volume")]
+    pub volume: f32,
+}
+
+fn default_volume() -> f32 {
+    1.0
+}
+
+impl SpeakRequest {
+    /// Clamp volume to valid range after deserialization.
+    pub fn validated(mut self) -> Self {
+        self.volume = self.volume.clamp(0.0, 5.0);
+        self
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -412,7 +426,7 @@ async fn route(
         }
         ("POST", "/speak") => {
             let req: SpeakRequest = match serde_json::from_slice(body) {
-                Ok(r) => r,
+                Ok(r) => SpeakRequest::validated(r),
                 Err(e) => {
                     let resp = serde_json::json!({"success": false, "error": format!("invalid JSON: {e}")});
                     return ("400 Bad Request", resp.to_string());
@@ -433,6 +447,7 @@ async fn route(
 
                 let text = req.text.clone();
                 let ref_audio = req.ref_audio.clone();
+                let volume = req.volume;
                 let state_clone = Arc::clone(state);
 
                 let result = tokio::task::spawn_blocking(move || {
@@ -459,6 +474,7 @@ async fn route(
                     drop(server_guard);
 
                     // Play the WAV
+                    audio::apply_wav_gain(&wav_path, volume)?;
                     audio::play_wav_blocking(&wav_path)?;
                     let _ = std::fs::remove_file(&wav_path);
 
@@ -491,6 +507,7 @@ async fn route(
                     ref_audio: req.ref_audio.clone(),
                     ref_text: req.ref_text.clone(),
                     model: req.model.clone(),
+                    volume: req.volume,
                 };
                 let backend_name = req.backend.clone();
                 let text = req.text.clone();
@@ -550,6 +567,7 @@ pub fn speak_via_daemon(text: &str, backend: &str, opts: &SpeakOptions) -> Resul
         ref_audio: opts.ref_audio.clone(),
         ref_text: opts.ref_text.clone(),
         model: opts.model.clone(),
+        volume: opts.volume,
     };
 
     let resp: SpeakResponse = reqwest::blocking::Client::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,14 @@ use vox::backend::{self, SpeakOptions};
 use vox::config::DEFAULT_BACKEND;
 use vox::{clone, daemon, db, init, input, mcp, pack, tui};
 
+fn parse_volume(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("{e}"))?;
+    if !(0.0..=5.0).contains(&v) {
+        return Err("volume must be between 0.0 and 5.0".to_string());
+    }
+    Ok(v)
+}
+
 #[derive(Parser)]
 #[command(name = "vox", version, about = "Voice Command — read text aloud")]
 struct Cli {
@@ -40,6 +48,10 @@ struct Cli {
     /// TTS model (e.g. mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit for faster inference)
     #[arg(short = 'm', long)]
     model: Option<String>,
+
+    /// Volume multiplier (1.0 = normal, 0.5 = half, 2.0 = double, range: 0.0–5.0)
+    #[arg(long, default_value = "1.0", value_parser = parse_volume)]
+    volume: f32,
 
     /// List available voices for the selected backend
     #[arg(long)]
@@ -313,6 +325,7 @@ fn handle_speak(cli: Cli) -> Result<()> {
         ref_audio,
         ref_text,
         model,
+        volume: cli.volume,
     };
 
     let start = Instant::now();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -209,6 +209,10 @@ fn tool_definitions() -> Value {
                     "rate": {
                         "type": "integer",
                         "description": "Speech rate in words per minute (say backend only)"
+                    },
+                    "volume": {
+                        "type": "number",
+                        "description": "Volume multiplier (1.0 = normal, 0.5 = half, 2.0 = double)"
                     }
                 },
                 "required": ["text"]
@@ -487,6 +491,12 @@ fn tool_speak(args: &Value) -> ToolResult {
         .and_then(|v| v.as_str())
         .map(String::from)
         .or(prefs.style);
+    let volume = args
+        .get("volume")
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32)
+        .unwrap_or(1.0)
+        .clamp(0.0, 5.0);
 
     // Resolve voice clone
     let mut ref_audio = None;
@@ -525,6 +535,7 @@ fn tool_speak(args: &Value) -> ToolResult {
         ref_audio,
         ref_text,
         model: None,
+        volume,
     };
 
     let start = std::time::Instant::now();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -23,8 +23,11 @@ enum Screen {
     Voice,
     Language,
     Style,
+    Volume,
     Test,
 }
+
+const VOLUME_PRESETS: &[&str] = &["0.5", "0.75", "1.0", "1.25", "1.5", "2.0", "3.0"];
 
 struct App {
     screen: Screen,
@@ -36,6 +39,7 @@ struct App {
     lang_idx: usize,
     styles: Vec<&'static str>,
     style_idx: usize,
+    volume_idx: usize,
     status: String,
     should_quit: bool,
 }
@@ -96,6 +100,8 @@ impl App {
             .and_then(|v| voices.iter().position(|x| x == v))
             .unwrap_or(0);
 
+        let volume_idx = VOLUME_PRESETS.iter().position(|x| *x == "1.0").unwrap_or(2);
+
         Ok(Self {
             screen: Screen::Backend,
             backends,
@@ -106,6 +112,7 @@ impl App {
             lang_idx,
             styles,
             style_idx,
+            volume_idx,
             status: "Arrow keys to navigate, Enter to select, Tab to switch section, T to test, S to save, Q to quit".into(),
             should_quit: false,
         })
@@ -139,13 +146,18 @@ impl App {
         if s == "(default)" { None } else { Some(s) }
     }
 
+    fn selected_volume(&self) -> f32 {
+        VOLUME_PRESETS[self.volume_idx].parse().unwrap_or(1.0)
+    }
+
     fn current_list_len(&self) -> usize {
         match self.screen {
             Screen::Backend => self.backends.len(),
             Screen::Voice => self.voices.len(),
             Screen::Language => self.languages.len(),
             Screen::Style => self.styles.len(),
-            Screen::Test => 2, // "Speak test" / "Back"
+            Screen::Volume => VOLUME_PRESETS.len(),
+            Screen::Test => 2,
         }
     }
 
@@ -155,6 +167,7 @@ impl App {
             Screen::Voice => self.voice_idx,
             Screen::Language => self.lang_idx,
             Screen::Style => self.style_idx,
+            Screen::Volume => self.volume_idx,
             Screen::Test => 0,
         }
     }
@@ -173,6 +186,7 @@ impl App {
             Screen::Voice => self.voice_idx = idx,
             Screen::Language => self.lang_idx = idx,
             Screen::Style => self.style_idx = idx,
+            Screen::Volume => self.volume_idx = idx,
             Screen::Test => {}
         }
     }
@@ -197,7 +211,8 @@ impl App {
             Screen::Backend => Screen::Voice,
             Screen::Voice => Screen::Language,
             Screen::Language => Screen::Style,
-            Screen::Style => Screen::Test,
+            Screen::Style => Screen::Volume,
+            Screen::Volume => Screen::Test,
             Screen::Test => Screen::Backend,
         };
     }
@@ -208,7 +223,8 @@ impl App {
             Screen::Voice => Screen::Backend,
             Screen::Language => Screen::Voice,
             Screen::Style => Screen::Language,
-            Screen::Test => Screen::Style,
+            Screen::Volume => Screen::Style,
+            Screen::Test => Screen::Volume,
         };
     }
 
@@ -218,6 +234,7 @@ impl App {
             voice: self.selected_voice().map(String::from),
             lang: Some(self.selected_lang().to_string()),
             style: self.selected_style().map(String::from),
+            volume: self.selected_volume(),
             ..Default::default()
         };
         let text = match self.selected_lang() {
@@ -302,12 +319,13 @@ fn draw(frame: &mut Frame, app: &App) {
         outer[0],
     );
 
-    // Main area: 5 columns
+    // Main area: 6 columns
     let cols = Layout::horizontal([
-        Constraint::Percentage(20),
-        Constraint::Percentage(25),
-        Constraint::Percentage(15),
-        Constraint::Percentage(20),
+        Constraint::Percentage(18),
+        Constraint::Percentage(22),
+        Constraint::Percentage(12),
+        Constraint::Percentage(16),
+        Constraint::Percentage(12),
         Constraint::Percentage(20),
     ])
     .split(outer[1]);
@@ -358,6 +376,18 @@ fn draw(frame: &mut Frame, app: &App) {
         cols[3],
     );
 
+    // Volume list
+    let volume_items: Vec<&str> = VOLUME_PRESETS.to_vec();
+    frame.render_widget(
+        render_list(
+            "Volume",
+            &volume_items,
+            app.volume_idx,
+            app.screen == Screen::Volume,
+        ),
+        cols[4],
+    );
+
     // Summary + actions
     let summary = vec![
         Line::from(vec![
@@ -382,6 +412,13 @@ fn draw(frame: &mut Frame, app: &App) {
                 Style::default().fg(Color::White),
             ),
         ]),
+        Line::from(vec![
+            Span::styled("Volume:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{}x", VOLUME_PRESETS[app.volume_idx]),
+                Style::default().fg(Color::White),
+            ),
+        ]),
         Line::from(""),
         Line::from(Span::styled(
             "[T] Test  [S] Save  [Q] Quit",
@@ -402,7 +439,7 @@ fn draw(frame: &mut Frame, app: &App) {
                 .title(" Config ")
                 .border_style(border_style),
         ),
-        cols[4],
+        cols[5],
     );
 
     // Status bar


### PR DESCRIPTION
## Summary
- Add `--volume` multiplier (0.0–5.0) across CLI, MCP, and daemon
- Fix WAV spec mismatch in `apply_wav_gain` (always write 16-bit int)
- Fix `SpeakOptions::default()` volume from 0.0 to 1.0
- Validate volume range at all entry points (CLI rejects, MCP/daemon clamp)
- Update all 6 README translations with volume example

## Test plan
- [x] `cargo build` passes
- [x] `--volume 6.0` rejected by CLI
- [x] GPU test: 1.0x vs 2.5x gain verified (exact 2.5x scaling, no clipping)
- [x] WAV output format correct (Int 16bit) after gain

🤖 Generated with [Claude Code](https://claude.com/claude-code)