### PR TITLE
fix: align backend preference validation with runtime registry

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -54,6 +54,7 @@ pub trait TtsBackend {
 /// Names of backends compiled into the current build. Single source of truth
 /// for backend validation (used by db preference setter, TUI, etc.).
 pub fn supported_backends() -> Vec<&'static str> {
+    #[allow(unused_mut)]
     let mut v: Vec<&'static str> = vec!["piper", "qwen-native", "voxtream"];
     #[cfg(feature = "kokoro")]
     v.push("kokoro");

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -51,6 +51,20 @@ pub trait TtsBackend {
     fn is_available(&self) -> bool;
 }
 
+/// Names of backends compiled into the current build. Single source of truth
+/// for backend validation (used by db preference setter, TUI, etc.).
+pub fn supported_backends() -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = vec!["piper", "qwen-native", "voxtream"];
+    #[cfg(feature = "kokoro")]
+    v.push("kokoro");
+    #[cfg(target_os = "macos")]
+    {
+        v.push("say");
+        v.push("qwen");
+    }
+    v
+}
+
 pub fn get_backend(name: &str) -> Result<Box<dyn TtsBackend>> {
     match name {
         #[cfg(feature = "kokoro")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -153,10 +153,7 @@ pub fn set_preference(conn: &Connection, key: &str, value: &str) -> Result<()> {
             }
         }
         "backend" => {
-            #[cfg(target_os = "macos")]
-            let valid_backends = ["kokoro", "say", "qwen", "qwen-native"];
-            #[cfg(not(target_os = "macos"))]
-            let valid_backends = ["kokoro", "qwen-native"];
+            let valid_backends = crate::backend::supported_backends();
             if !valid_backends.contains(&value) {
                 anyhow::bail!(
                     "Unknown backend: {value}. Must be one of: {}",

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -89,7 +89,15 @@ fn test_set_preference_invalid_rate() {
 #[test]
 fn test_set_preference_invalid_backend() {
     let conn = db::open_in_memory().unwrap();
-    assert!(db::set_preference(&conn, "backend", "piper").is_err());
+    assert!(db::set_preference(&conn, "backend", "nonexistent-backend").is_err());
+}
+
+#[test]
+fn test_set_preference_accepts_piper() {
+    let conn = db::open_in_memory().unwrap();
+    db::set_preference(&conn, "backend", "piper").unwrap();
+    let prefs = db::get_preferences(&conn).unwrap();
+    assert_eq!(prefs.backend.as_deref(), Some("piper"));
 }
 
 #[test]

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -123,8 +123,9 @@ fn backend_validation_rejects_unknown() {
 #[test]
 fn backend_validation_accepts_valid() {
     let conn = db::open_in_memory().unwrap();
-    // kokoro should always be valid on all platforms
-    assert!(db::set_preference(&conn, "backend", "kokoro").is_ok());
+    // piper and qwen-native are always compiled in.
+    assert!(db::set_preference(&conn, "backend", "piper").is_ok());
+    assert!(db::set_preference(&conn, "backend", "qwen-native").is_ok());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/ux_test.rs
+++ b/tests/ux_test.rs
@@ -26,7 +26,7 @@ fn invalid_backend_shows_available_options() {
         .args(["config", "set", "backend", "nonexistent"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("kokoro").or(predicate::str::contains("say")));
+        .stderr(predicate::str::contains("piper").or(predicate::str::contains("qwen-native")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

@ManuInNZ reported on #59 that after the espeak fix:

```
❯ vox bench
  piper            3582ms  ███████
  say              4009ms  ████████
  qwen-native     11193ms  ████████████████████
  Best: piper (3582ms)
Error: Unknown backend: piper. Must be one of: kokoro, say, qwen, qwen-native
```

And

```
❯ vox config set backend kokoro
backend = kokoro
❯ vox -b kokoro "Fast TTS."
Error: Unknown backend: kokoro
```

### Root cause

`db::set_preference` validated the `backend` key against a hard-coded list that was out of sync with `backend::get_backend`:

- macOS list was `["kokoro", "say", "qwen", "qwen-native"]` — missing `piper` (the configured `DEFAULT_BACKEND`) and `voxtream`
- The same list accepted `kokoro`, but kokoro is gated behind a feature flag that's off by default and not in any released binary

### Fix

Introduce `backend::supported_backends()` as the single source of truth (built from the same `cfg` gates as `get_backend`), and call it from `set_preference`. After this:

- `vox bench` saving piper as default works on every platform
- `vox config set backend X` rejects X upfront when X isn't compiled in, instead of letting the user save a value that then fails at runtime

Scope-limited fix — no behavior change to backends themselves.

## Test plan

- [ ] CI green on Linux CPU + macOS Metal (the platforms my last PR also passed)
- [ ] Manual on Mac: `vox bench` → no error after "Best: piper"
- [ ] Manual: `vox config set backend piper` succeeds; `vox config set backend kokoro` rejects upfront (since kokoro feature is off in release)