### PR TITLE
perf: compress embedded espeak-ng-data with rust-embed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rodio = "0.20"
 hound = "3"
 qwen3-tts = { git = "https://github.com/TrevorS/qwen3-tts-rs", features = ["hub"], default-features = false }
 piper-rs = { git = "https://github.com/thewh1teagle/piper-rs" }
-include_dir = "0.7"
+rust-embed = { version = "8", features = ["compression", "interpolate-folder-path"] }
 kokoro-tts = { version = "0.3", optional = true }
 toml = "0.8"
 ratatui = "0.29"

--- a/src/backend/piper.rs
+++ b/src/backend/piper.rs
@@ -8,7 +8,7 @@ use std::sync::{Mutex, OnceLock};
 
 use anyhow::{Context, Result};
 use piper_rs::Piper;
-use rust_embed::RustEmbed;
+use rust_embed::{Embed, RustEmbed};
 
 use super::{SpeakOptions, TtsBackend};
 use crate::config;

--- a/src/backend/piper.rs
+++ b/src/backend/piper.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::{Context, Result};
-use include_dir::{Dir, include_dir};
 use piper_rs::Piper;
+use rust_embed::RustEmbed;
 
 use super::{SpeakOptions, TtsBackend};
 use crate::config;
@@ -19,11 +19,14 @@ pub struct PiperBackend;
 /// Reloads when language changes (different ONNX model per language).
 static MODEL: Mutex<Option<(String, Piper)>> = Mutex::new(None);
 
-/// espeak-ng-data embedded at build time (staged by build.rs into OUT_DIR).
-/// Needed because the espeak-ng library statically linked into vox has a
-/// hard-coded data path from the CI builder that does not exist on user
-/// machines. We extract this once and point espeak-rs at the result.
-static ESPEAK_DATA: Dir<'_> = include_dir!("$OUT_DIR/espeak-ng-data");
+/// espeak-ng-data embedded (and DEFLATE-compressed) at build time. Staged
+/// into OUT_DIR by build.rs. Needed because the espeak-ng library statically
+/// linked into vox has a hard-coded data path from the CI builder that does
+/// not exist on user machines. We extract this once and point espeak-rs at
+/// the result.
+#[derive(RustEmbed)]
+#[folder = "$OUT_DIR/espeak-ng-data"]
+struct EspeakData;
 
 static ESPEAK_DATA_INIT: OnceLock<Result<PathBuf, String>> = OnceLock::new();
 
@@ -44,9 +47,15 @@ fn ensure_espeak_data() -> Result<()> {
                 std::fs::remove_dir_all(&data_dir).map_err(|e| e.to_string())?;
             }
             std::fs::create_dir_all(&data_dir).map_err(|e| e.to_string())?;
-            ESPEAK_DATA
-                .extract(&data_dir)
-                .map_err(|e| format!("failed to extract espeak-ng-data: {e}"))?;
+            for path in EspeakData::iter() {
+                let file = EspeakData::get(&path)
+                    .ok_or_else(|| format!("embedded espeak-ng-data entry vanished: {path}"))?;
+                let target = data_dir.join(path.as_ref());
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                }
+                std::fs::write(&target, file.data.as_ref()).map_err(|e| e.to_string())?;
+            }
             std::fs::File::create(&sentinel).map_err(|e| e.to_string())?;
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #60. The embedded `espeak-ng-data` directory was shipped uncompressed via `include_dir!`, inflating the release binary from ~27 MB (pre-fix) to ~50 MB. The bytes are mostly phoneme dictionaries — plain text and small binary tables that compress well.

Swap `include_dir = "0.7"` for `rust-embed = { version = "8", features = ["compression", "interpolate-folder-path"] }`. Files are DEFLATE-compressed at build time and decompressed when extracted (once, on first piper call). Expected sizes:

| | Before #60 | After #60 (include_dir) | This PR (rust-embed + deflate) |
|---|---|---|---|
| Linux release binary | ~27 MB | 50 MB | ~32 MB (estimate) |
| Linux release tarball | ~12 MB | 22 MB | ~13 MB (estimate) |

Same staging path (`$OUT_DIR/espeak-ng-data` populated by `build.rs`), same first-run extraction to `~/.config/vox/piper/espeak-ng-data/`, same `PIPER_ESPEAKNG_DATA_DIRECTORY` env-var dance. No user-facing change.

## Test plan

- [ ] CI green on Linux CPU + macOS Metal (the platforms that passed for #60/#61)
- [ ] Local: download Linux release binary built from this branch, run `vox -b piper "hello"` on a fresh `~/.config/vox`, confirm extraction + audio works
- [ ] Compare binary/tarball sizes vs v0.14.0