### PR TITLE
ci: fix Windows CRT mismatch and mark CUDA non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    # CUDA matrix entries are best-effort: GH-hosted runners' kernel mismatch
+    # currently breaks nvidia-dkms (Jimver/cuda-toolkit action). Mirror the
+    # non-blocking behavior already applied in release.yml.
+    continue-on-error: ${{ matrix.cuda == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +61,16 @@ jobs:
         with:
           cuda: '12.6.3'
           method: network
+
+      # esaxx-rs forces /MT via .static_crt(true) but ort-sys prebuilt links
+      # against /MD. Force /MD on Windows so cc's last flag wins and the
+      # CRT matches ort-sys. Without this, link fails with LNK2038.
+      - name: Set Windows MSVC runtime flags
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          echo "CFLAGS=/MD" >> $env:GITHUB_ENV
+          echo "CXXFLAGS=/MD" >> $env:GITHUB_ENV
 
       - name: Cache cargo
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Force Windows MSVC builds to use \`/MD\` (dynamic CRT) so esaxx-rs aligns with ort-sys's prebuilt \`/MD\` artifacts — fixes the persistent LNK2038 link error on \`Windows (CPU)\` and \`Windows (CUDA)\` CI jobs.
- Mirror \`release.yml\`'s \`continue-on-error: \${{ matrix.cuda == true }}\` on CI's CUDA matrix entries so the upstream nvidia-dkms install failure (GH-hosted runner kernel mismatch) doesn't block the rest of the matrix.

## Why
\`esaxx-rs/build.rs\` hardcodes \`.static_crt(true)\` → MSVC emits \`/MT\`. \`ort-sys\` ships a prebuilt binary linked with \`/MD\`. The link step then aborts with \`LNK2038: mismatch detected for 'RuntimeLibrary'\`. Setting \`CFLAGS=/MD\` and \`CXXFLAGS=/MD\` on Windows leverages MSVC's "last flag wins" rule so esaxx-rs recompiles with \`/MD\`.

Release builds currently mask the same mismatch (likely via LTO + \`panic=abort\` + strip), so this PR intentionally only touches \`ci.yml\`.

## Test plan
- [ ] All matrix jobs except CUDA pass on this PR
- [ ] CUDA jobs may fail but no longer fail the workflow
- [ ] Diff confirmed minimal (14 lines added, no Rust touched)