### PR TITLE
fix: respect configured/system lang in MCP instructions instead of hardcoding French

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,6 +4135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysctl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4809,6 +4818,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sys-locale",
  "tempfile",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ kokoro-tts = { version = "0.3", optional = true }
 toml = "0.8"
 ratatui = "0.29"
 crossterm = "0.28"
+sys-locale = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -20,7 +20,7 @@ const SERVER_NAME: &str = "vox";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
-const VOX_INSTRUCTIONS: &str = "\
+const VOX_INSTRUCTIONS_TEMPLATE: &str = "\
 You have access to vox, a text-to-speech tool. Use it to give spoken feedback to the user.\n\
 \n\
 WHEN TO SPEAK (vox_speak):\n\
@@ -35,7 +35,7 @@ WHEN NOT TO SPEAK:\n\
 \n\
 GUIDELINES:\n\
 - Keep summaries under 2 sentences\n\
-- Use French by default (the user prefers it)\n\
+{language_guideline}\n\
 - Use vox_config_show to check the user's preferred voice/backend before first use\n\
 - For longer explanations, use vox_speak with a concise summary, not the full text\n\
 \n\
@@ -43,6 +43,39 @@ VOICE CONVERSATION (vox_hear + vox_speak):\n\
 You can have a voice conversation with the user — you ARE the brain, no API key needed.\n\
 Loop: vox_hear (listen) → you think → vox_speak (respond). Repeat until the user says goodbye.\n\
 When the user asks to \"chat\" or \"talk\" or \"parler\", start this loop.";
+
+fn configured_lang() -> Option<String> {
+    db::open()
+        .ok()
+        .and_then(|conn| db::get_preferences(&conn).ok())
+        .and_then(|prefs| prefs.lang)
+        .filter(|lang| !lang.is_empty())
+}
+
+fn normalize_locale(locale: &str) -> Option<String> {
+    let lang = locale.split(['-', '_']).next()?.to_lowercase();
+    crate::config::SUPPORTED_LANGS
+        .contains(&lang.as_str())
+        .then_some(lang)
+}
+
+fn system_lang() -> Option<String> {
+    normalize_locale(&sys_locale::get_locale()?)
+}
+
+fn default_lang() -> Option<String> {
+    configured_lang().or_else(system_lang)
+}
+
+fn vox_instructions(lang: Option<&str>) -> String {
+    let language_guideline = match lang {
+        Some(lang) => format!(
+            "- Speak in the user's language ({lang}); honour any language they explicitly ask for"
+        ),
+        None => "- Match the language the user is writing in".to_string(),
+    };
+    VOX_INSTRUCTIONS_TEMPLATE.replace("{language_guideline}", &language_guideline)
+}
 
 #[derive(Deserialize)]
 struct JsonRpcMessage {
@@ -144,7 +177,7 @@ fn handle_initialize(id: Value) -> JsonRpcResponse {
                 "name": SERVER_NAME,
                 "version": SERVER_VERSION
             },
-            "instructions": VOX_INSTRUCTIONS
+            "instructions": vox_instructions(default_lang().as_deref())
         }),
     )
 }
@@ -969,5 +1002,48 @@ fn tool_hear(args: &Value) -> ToolResult {
         } else {
             tool_ok(text)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instructions_default_to_user_language_when_unset() {
+        let instructions = vox_instructions(None);
+        assert!(instructions.contains("Match the language the user is writing in"));
+        assert!(!instructions.contains("Use French by default"));
+    }
+
+    #[test]
+    fn instructions_follow_configured_language() {
+        assert!(vox_instructions(Some("fr")).contains("Speak in the user's language (fr)"));
+        assert!(vox_instructions(Some("es")).contains("Speak in the user's language (es)"));
+        assert!(vox_instructions(Some("ja")).contains("Speak in the user's language (ja)"));
+    }
+
+    #[test]
+    fn normalize_locale_maps_primary_subtag_when_supported() {
+        assert_eq!(normalize_locale("fr-FR"), Some("fr".to_string()));
+        assert_eq!(normalize_locale("en_US"), Some("en".to_string()));
+        assert_eq!(normalize_locale("de-AT"), Some("de".to_string()));
+        assert_eq!(normalize_locale("FR"), Some("fr".to_string()));
+        assert_eq!(normalize_locale("zh-Hant"), Some("zh".to_string()));
+    }
+
+    #[test]
+    fn normalize_locale_rejects_unsupported_or_empty() {
+        assert_eq!(normalize_locale("cy-GB"), None);
+        assert_eq!(normalize_locale("C"), None);
+        assert_eq!(normalize_locale(""), None);
+    }
+
+    #[test]
+    fn system_lang_is_supported_or_none() {
+        assert!(
+            system_lang()
+                .is_none_or(|lang| crate::config::SUPPORTED_LANGS.contains(&lang.as_str()))
+        );
     }
 }


### PR DESCRIPTION
I kept ending up with vox talking to me in French. I'd tell it to switch to English, I set `lang en`, the works — and it'd behave for a bit, then a session or two later French would quietly creep back in. After enough rounds of this I went digging, and the reason is that the MCP server's `instructions` blob hardcodes it:

```
- Use French by default (the user prefers it)
```

That string gets injected into the assistant on every `initialize`, so no amount of config ever made English stick. `vox config set lang` only changes the *synthesis* language, not the language the assistant actually writes its spoken summaries in — so the two never lined up.

This makes that one guideline come from the configured language instead, with a sensible fallback chain:

- `lang` is set → `Speak in the user's language (<code>)` — so French still works, you just `vox config set lang fr`
- no `lang` set → fall back to the **system locale** (e.g. `fr_FR` → `fr`), validated against `SUPPORTED_LANGS`
- nothing usable → `Match the language the user is writing in` (no language assumed)

I pulled the instruction-building into a small `vox_instructions(lang)` function and a `normalize_locale` helper so the logic is unit-testable, and `handle_initialize` resolves the language and passes it in. `sys-locale` is added for the system-locale lookup (works on macOS even when `$LANG` isn't set). I left the `vox init` output and its tests alone to keep the change focused.

Tests cover the configured-language formatting, the neutral unset fallback, and the locale normalization (`fr-FR`→`fr`, `en_US`→`en`, unsupported/empty → none). `cargo test`, `cargo fmt --check` and `cargo clippy` are all clean locally.
